### PR TITLE
Add a 'shared secret' conf for cloak key

### DIFF
--- a/inspircd.conf
+++ b/inspircd.conf
@@ -1,5 +1,6 @@
 <config format="xml">
 <include file="conf/perserver.conf">
+<include file="conf/secrets.conf">
 
 <server
     name="&servername;"

--- a/modules.conf
+++ b/modules.conf
@@ -51,7 +51,7 @@
 
 <module name="m_cloaking.so">
 <cloak mode="full"
-       key="0x3ff8f880"
+       key="&cloaksecret;"
        prefix="no-">
 
 <module name="m_clones.so">

--- a/secrets.example.conf
+++ b/secrets.example.conf
@@ -1,0 +1,1 @@
+<define name="cloaksecret" value="secret">


### PR DESCRIPTION
The key shouldn't have been included in the config in plaintext in the
first place, whoops!

The impact of the key being present is not that it reveals hostmasks
since the cloaking process is lossy, but it does make it possible to
narrow down a hostmask to a much smaller number of possible inputs (even
if it can't be definitively identified as one of them).